### PR TITLE
feat: Audit for unused components

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Detect bloated HTML attributes introduced when content is pasted from external t
 - Detects generic `data-*` attributes and inline event handlers (`onclick=`, `onerror=`, etc.)
 - Shows context snippets around each finding for manual review
 
+### Component Usage Audit
+Audit which of your known Butter CMS components are actually used across individual pages — complementing Butter CMS's built-in view, which shows which page types reference a component:
+- Add your component slugs to the Known Components configuration
+- Scans all fields recursively — detects both object key-based and `type` field-based component references
+- Shows usage counts for each known component with a list of individual pages where it appears
+- Warns when a component has zero individual page usages, noting that Butter CMS may still reference it at the page type level
+
 ## 🔧 Development
 
 Built with:

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "@vue/eslint-config-typescript": "^14.7.0",
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",
-    "eslint": "^9.39.2",
+    "eslint": "^9.39.3",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-vue": "^10.8.0",
-    "happy-dom": "^20.6.3",
+    "happy-dom": "^20.7.0",
     "jiti": "^2.6.1",
     "prettier": "3.8.1",
     "sass": "^1.97.3",
@@ -36,6 +36,6 @@
     "vite": "^7.3.1",
     "vite-plugin-vue-devtools": "^8.0.6",
     "vitest": "^4.0.18",
-    "vue-tsc": "^3.2.4"
+    "vue-tsc": "^3.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,13 +26,13 @@ importers:
         version: 6.0.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(sass@1.97.3))(vue@3.5.28(typescript@5.9.3))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))
+        version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))
       '@vitest/eslint-plugin':
         specifier: ^1.6.9
-        version: 1.6.9(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))
+        version: 1.6.9(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))
       '@vue/eslint-config-typescript':
         specifier: ^14.7.0
-        version: 14.7.0(eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.2(jiti@2.6.1))))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 14.7.0(eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1))))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -40,17 +40,17 @@ importers:
         specifier: ^0.8.1
         version: 0.8.1(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3))
       eslint:
-        specifier: ^9.39.2
-        version: 9.39.2(jiti@2.6.1)
+        specifier: ^9.39.3
+        version: 9.39.3(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.2(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-vue:
         specifier: ^10.8.0
-        version: 10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.2(jiti@2.6.1)))
+        version: 10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1)))
       happy-dom:
-        specifier: ^20.6.3
-        version: 20.6.3
+        specifier: ^20.7.0
+        version: 20.7.0
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -74,10 +74,10 @@ importers:
         version: 8.0.6(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(sass@1.97.3))(vue@3.5.28(typescript@5.9.3))
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3)
+        version: 4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3)
       vue-tsc:
-        specifier: ^3.2.4
-        version: 3.2.4(typescript@5.9.3)
+        specifier: ^3.2.5
+        version: 3.2.5(typescript@5.9.3)
 
 packages:
 
@@ -460,8 +460,8 @@ packages:
     resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.39.2':
-    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
+  '@eslint/js@9.39.3':
+    resolution: {integrity: sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.7':
@@ -930,14 +930,14 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@volar/language-core@2.4.27':
-    resolution: {integrity: sha512-DjmjBWZ4tJKxfNC1F6HyYERNHPYS7L7OPFyCrestykNdUZMFYzI9WTyvwPcaNaHlrEUwESHYsfEw3isInncZxQ==}
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
-  '@volar/source-map@2.4.27':
-    resolution: {integrity: sha512-ynlcBReMgOZj2i6po+qVswtDUeeBRCTgDurjMGShbm8WYZgJ0PA4RmtebBJ0BCYol1qPv3GQF6jK7C9qoVc7lg==}
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
-  '@volar/typescript@2.4.27':
-    resolution: {integrity: sha512-eWaYCcl/uAPInSK2Lze6IqVWaBu/itVqR5InXcHXFyles4zO++Mglt3oxdgj75BDcv1Knr9Y93nowS8U3wqhxg==}
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
 
   '@vue/babel-helper-vue-transform-on@1.5.0':
     resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
@@ -1010,8 +1010,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@3.2.4':
-    resolution: {integrity: sha512-bqBGuSG4KZM45KKTXzGtoCl9cWju5jsaBKaJJe3h5hRAAWpZUuj5G+L+eI01sPIkm4H6setKRlw7E85wLdDNew==}
+  '@vue/language-core@3.2.5':
+    resolution: {integrity: sha512-d3OIxN/+KRedeM5wQ6H6NIpwS3P5gC9nmyaHgBk+rO6dIsjY+tOh4UlPpiZbAh3YtLdCGEX4M16RmsBqPmJV+g==}
 
   '@vue/reactivity@3.5.28':
     resolution: {integrity: sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==}
@@ -1314,8 +1314,8 @@ packages:
     resolution: {integrity: sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@9.39.2:
-    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
+  eslint@9.39.3:
+    resolution: {integrity: sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -1427,8 +1427,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  happy-dom@20.6.3:
-    resolution: {integrity: sha512-QAMY7d228dHs8gb9NG4SJ3OxQo4r+NGN8pOXGZ3SGfQf/XYuuYubrtZ25QVY2WoUQdskhRXSXb4R4mcRk+hV1w==}
+  happy-dom@20.7.0:
+    resolution: {integrity: sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -2104,8 +2104,8 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
-  vue-tsc@3.2.4:
-    resolution: {integrity: sha512-xj3YCvSLNDKt1iF9OcImWHhmYcihVu9p4b9s4PGR/qp6yhW+tZJaypGxHScRyOrdnHvaOeF+YkZOdKwbgGvp5g==}
+  vue-tsc@3.2.5:
+    resolution: {integrity: sha512-/htfTCMluQ+P2FISGAooul8kO4JMheOTCbCy4M6dYnYYjqLe3BExZudAua6MSIKSFYQtFOYAll7XobYwcpokGA==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -2532,9 +2532,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2569,7 +2569,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.39.2': {}
+  '@eslint/js@9.39.3': {}
 
   '@eslint/object-schema@2.1.7': {}
 
@@ -2802,15 +2802,15 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.56.0
-      '@typescript-eslint/type-utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.0
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -2818,14 +2818,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2866,13 +2866,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2912,24 +2912,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.55.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2950,7 +2950,7 @@ snapshots:
       vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(sass@1.97.3)
       vue: 3.5.28(typescript@5.9.3)
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -2962,16 +2962,16 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3)
+      vitest: 4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3)
 
-  '@vitest/eslint-plugin@1.6.9(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))':
+  '@vitest/eslint-plugin@1.6.9(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.3(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3)
+      vitest: 4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3014,15 +3014,15 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@volar/language-core@2.4.27':
+  '@volar/language-core@2.4.28':
     dependencies:
-      '@volar/source-map': 2.4.27
+      '@volar/source-map': 2.4.28
 
-  '@volar/source-map@2.4.27': {}
+  '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.27':
+  '@volar/typescript@2.4.28':
     dependencies:
-      '@volar/language-core': 2.4.27
+      '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
@@ -3038,7 +3038,7 @@ snapshots:
       '@babel/types': 7.28.6
       '@vue/babel-helper-vue-transform-on': 1.5.0
       '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.28.6)
-      '@vue/shared': 3.5.27
+      '@vue/shared': 3.5.28
     optionalDependencies:
       '@babel/core': 7.28.6
     transitivePeerDependencies:
@@ -3159,24 +3159,24 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/eslint-config-typescript@14.7.0(eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.2(jiti@2.6.1))))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@vue/eslint-config-typescript@14.7.0(eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1))))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-plugin-vue: 10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.2(jiti@2.6.1)))
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.3(jiti@2.6.1)
+      eslint-plugin-vue: 10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1)))
       fast-glob: 3.3.3
-      typescript-eslint: 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      vue-eslint-parser: 10.4.0(eslint@9.39.2(jiti@2.6.1))
+      typescript-eslint: 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      vue-eslint-parser: 10.4.0(eslint@9.39.3(jiti@2.6.1))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/language-core@3.2.4':
+  '@vue/language-core@3.2.5':
     dependencies:
-      '@volar/language-core': 2.4.27
-      '@vue/compiler-dom': 3.5.27
-      '@vue/shared': 3.5.27
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.28
+      '@vue/shared': 3.5.28
       alien-signals: 3.1.2
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -3442,22 +3442,22 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)):
+  eslint-config-prettier@10.1.8(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
 
-  eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.2(jiti@2.6.1))):
+  eslint-plugin-vue@10.8.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
-      eslint: 9.39.2(jiti@2.6.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
+      eslint: 9.39.3(jiti@2.6.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.7.3
-      vue-eslint-parser: 10.4.0(eslint@9.39.2(jiti@2.6.1))
+      vue-eslint-parser: 10.4.0(eslint@9.39.3(jiti@2.6.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -3470,15 +3470,15 @@ snapshots:
 
   eslint-visitor-keys@5.0.0: {}
 
-  eslint@9.39.2(jiti@2.6.1):
+  eslint@9.39.3(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
       '@eslint/eslintrc': 3.3.3
-      '@eslint/js': 9.39.2
+      '@eslint/js': 9.39.3
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
@@ -3608,7 +3608,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  happy-dom@20.6.3:
+  happy-dom@20.7.0:
     dependencies:
       '@types/node': 24.10.13
       '@types/whatwg-mimetype': 3.0.2
@@ -4121,13 +4121,13 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
-  typescript-eslint@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4221,7 +4221,7 @@ snapshots:
       jiti: 2.6.1
       sass: 1.97.3
 
-  vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.6.3)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3):
+  vitest@4.0.18(@types/node@24.10.13)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@27.4.0)(sass@1.97.3):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(sass@1.97.3))
@@ -4245,7 +4245,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.13
-      happy-dom: 20.6.3
+      happy-dom: 20.7.0
       jsdom: 27.4.0
     transitivePeerDependencies:
       - jiti
@@ -4264,10 +4264,10 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-eslint-parser@10.4.0(eslint@9.39.2(jiti@2.6.1)):
+  vue-eslint-parser@10.4.0(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.6.1)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -4276,10 +4276,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-tsc@3.2.4(typescript@5.9.3):
+  vue-tsc@3.2.5(typescript@5.9.3):
     dependencies:
-      '@volar/typescript': 2.4.27
-      '@vue/language-core': 3.2.4
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.2.5
       typescript: 5.9.3
 
   vue@3.5.28(typescript@5.9.3):

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -100,8 +100,8 @@ describe('App.vue', () => {
 
     it('renders Tab components for Search and Audit', () => {
       const wrapper = createWrapper()
-      const tabComponents = wrapper.findAllComponents({ name: 'Tab' })
-      expect(tabComponents).toHaveLength(2)
+      const tabPanelComponents = wrapper.findAllComponents({ name: 'TabPanel' })
+      expect(tabPanelComponents.length).toBeGreaterThanOrEqual(2)
     })
 
     it('renders SearchContent component within tabs', () => {
@@ -136,31 +136,33 @@ describe('App.vue', () => {
   describe('Tab Configuration', () => {
     it('Search tab has correct props', () => {
       const wrapper = createWrapper()
-      const tabs = wrapper.findAllComponents({ name: 'Tab' })
-      const searchTab = tabs[0]
+      const tabPanels = wrapper.findAllComponents({ name: 'TabPanel' })
+      const searchTab = tabPanels.find((t) => t.props('label') === 'Search')
 
+      expect(searchTab).toBeDefined()
       expect(searchTab!.props('label')).toBe('Search')
       expect(searchTab!.props('icon')).toBe('🔍')
-      expect(searchTab!.props('panelId')).toBe('search-panel')
       expect(searchTab!.props('index')).toBe(0)
     })
 
     it('Audit tab has correct props', () => {
       const wrapper = createWrapper()
-      const tabs = wrapper.findAllComponents({ name: 'Tab' })
-      const auditTab = tabs[1]
+      const tabPanels = wrapper.findAllComponents({ name: 'TabPanel' })
+      const auditTab = tabPanels.find((t) => t.props('label') === 'Audit')
 
+      expect(auditTab).toBeDefined()
       expect(auditTab!.props('label')).toBe('Audit')
       expect(auditTab!.props('icon')).toBe('⚠️')
-      expect(auditTab!.props('panelId')).toBe('audit-panel')
       expect(auditTab!.props('index')).toBe(1)
     })
   })
 
   describe('Tab Panels', () => {
-    it('search panel has correct id and role', () => {
+    it('search panel has correct id and role', async () => {
       const wrapper = createWrapper()
-      const searchPanel = wrapper.find('#search-panel')
+      await wrapper.vm.$nextTick()
+
+      const searchPanel = wrapper.find('#tab-panel-0')
 
       expect(searchPanel.exists()).toBe(true)
       expect(searchPanel.attributes('role')).toBe('tabpanel')
@@ -179,7 +181,7 @@ describe('App.vue', () => {
         await flushPromises()
       }
 
-      const auditPanel = wrapper.find('#audit-panel')
+      const auditPanel = wrapper.find('#tab-panel-1')
       expect(auditPanel.exists()).toBe(true)
       expect(auditPanel.attributes('role')).toBe('tabpanel')
       expect(auditPanel.attributes('aria-labelledby')).toBe('tab-1')

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,23 +12,15 @@
     <ApiConfiguration />
 
     <Tabs>
-      <template #tabs>
-        <Tab label="Search" icon="🔍" panel-id="search-panel" :index="0" />
-        <Tab label="Audit" icon="⚠️" panel-id="audit-panel" :index="1" />
-      </template>
-      <template #panels="{ activeTabIndex }">
-        <div id="search-panel" role="tabpanel" aria-labelledby="tab-0" v-if="activeTabIndex === 0">
-          <SearchContent />
-        </div>
-        <div
-          id="audit-panel"
-          role="tabpanel"
-          aria-labelledby="tab-1"
-          v-else-if="activeTabIndex === 1"
-        >
-          <AuditContent />
-        </div>
-      </template>
+      <TabPanel label="Search" icon="🔍" :index="0">
+        <SearchContent />
+      </TabPanel>
+      <TabPanel label="Audit" icon="⚠️" :index="1">
+        <AuditContent />
+      </TabPanel>
+      <TabPanel label="Components" icon="🧩" :index="2">
+        <ComponentsContent />
+      </TabPanel>
     </Tabs>
   </main>
   <Footer />
@@ -42,11 +34,14 @@ import Footer from './components/Footer.vue'
 import InfoBanner from './components/InfoBanner.vue'
 import ApiConfiguration from './components/ApiConfiguration.vue'
 import Tabs from './components/Tabs.vue'
-import Tab from './components/Tab.vue'
+import TabPanel from './components/TabPanel.vue'
 import WhatsNew from './components/WhatsNew.vue'
 
 const SearchContent = defineAsyncComponent(() => import('./components/Features/SearchContent.vue'))
 const AuditContent = defineAsyncComponent(() => import('./components/Features/AuditContent.vue'))
+const ComponentsContent = defineAsyncComponent(
+  () => import('./components/Features/ComponentsContent.vue'),
+)
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/ApiConfiguration.spec.ts
+++ b/src/components/ApiConfiguration.spec.ts
@@ -15,6 +15,7 @@ interface ApiConfigurationInstance extends ComponentPublicInstance {
   store: ReturnType<typeof useStore>
   pageTypeInput: string
   collectionKeyInput: string
+  knownComponentInput: string
 }
 
 // Helper to get typed component instance
@@ -488,9 +489,9 @@ describe('ApiConfiguration.vue', () => {
         const form = wrapper.findAll('form')[0]!
         await form.trigger('submit')
         expect(getVm(wrapper).store.pageTypes).toEqual([
+          'about_page',
           'landing_page',
           'product_page',
-          'about_page',
         ])
       })
 
@@ -502,9 +503,9 @@ describe('ApiConfiguration.vue', () => {
         const form = wrapper.findAll('form')[0]!
         await form.trigger('submit')
         expect(getVm(wrapper).store.pageTypes).toEqual([
+          'about_page',
           'landing_page',
           'product_page',
-          'about_page',
         ])
         expect(getVm(wrapper).store.pageTypes.length).toBe(3)
       })
@@ -565,7 +566,7 @@ describe('ApiConfiguration.vue', () => {
         await wrapper.vm.$nextTick()
         const forms = wrapper.findAll('form')
         await forms[1]!.trigger('submit')
-        expect(getVm(wrapper).store.collectionKeys).toEqual(['recipes', 'articles', 'products'])
+        expect(getVm(wrapper).store.collectionKeys).toEqual(['articles', 'products', 'recipes'])
       })
 
       it('filters out empty values in comma-separated collection keys', async () => {
@@ -575,7 +576,7 @@ describe('ApiConfiguration.vue', () => {
         await wrapper.vm.$nextTick()
         const forms = wrapper.findAll('form')
         await forms[1]!.trigger('submit')
-        expect(getVm(wrapper).store.collectionKeys).toEqual(['recipes', 'articles', 'products'])
+        expect(getVm(wrapper).store.collectionKeys).toEqual(['articles', 'products', 'recipes'])
         expect(getVm(wrapper).store.collectionKeys.length).toBe(3)
       })
 
@@ -586,7 +587,7 @@ describe('ApiConfiguration.vue', () => {
         await wrapper.vm.$nextTick()
         const forms = wrapper.findAll('form')
         await forms[1]!.trigger('submit')
-        expect(getVm(wrapper).store.collectionKeys).toEqual(['recipes', 'articles'])
+        expect(getVm(wrapper).store.collectionKeys).toEqual(['articles', 'recipes'])
         expect(getVm(wrapper).store.collectionKeys.length).toBe(2)
       })
 
@@ -787,6 +788,151 @@ describe('ApiConfiguration.vue', () => {
       const buttons = collectionForm.findAllComponents(Btn)
       expect(buttons.length).toBe(1)
       expect(buttons[0].text()).toBe('Add')
+    })
+  })
+
+  describe('Known Components Section', () => {
+    it('renders known components section heading', () => {
+      const wrapper = mount(ApiConfiguration)
+      expect(wrapper.text()).toContain('Components')
+    })
+
+    it('renders the known component TextInput', () => {
+      const wrapper = mount(ApiConfiguration)
+      const input = wrapper.find('#known-component-input')
+      expect(input.exists()).toBe(true)
+    })
+
+    it('shows empty state message when no known components are configured', () => {
+      const store = useStore()
+      store.knownComponents = []
+
+      const wrapper = mount(ApiConfiguration)
+      expect(wrapper.text()).toContain('No known components configured yet')
+    })
+
+    it('does not show Add button when known component input is empty', () => {
+      const wrapper = mount(ApiConfiguration)
+      const forms = wrapper.findAll('form')
+      const knownComponentForm = forms[2]!
+      const buttons = knownComponentForm.findAllComponents(Btn)
+      expect(buttons.length).toBe(0)
+    })
+
+    it('shows Add button when known component input has value', async () => {
+      const wrapper = mount(ApiConfiguration)
+      getVm(wrapper).knownComponentInput = 'hero_banner'
+      await wrapper.vm.$nextTick()
+
+      const forms = wrapper.findAll('form')
+      const knownComponentForm = forms[2]!
+      const buttons = knownComponentForm.findAllComponents(Btn)
+      expect(buttons.length).toBe(1)
+      expect(buttons[0].text()).toBe('Add')
+    })
+
+    it('adds a known component on form submit', async () => {
+      const store = useStore()
+      store.knownComponents = []
+
+      const wrapper = mount(ApiConfiguration)
+      getVm(wrapper).knownComponentInput = 'hero_banner'
+      await wrapper.vm.$nextTick()
+
+      const forms = wrapper.findAll('form')
+      await forms[2]!.trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      expect(store.knownComponents).toContain('hero_banner')
+    })
+
+    it('adds multiple components from comma-separated input', async () => {
+      const store = useStore()
+      store.knownComponents = []
+
+      const wrapper = mount(ApiConfiguration)
+      getVm(wrapper).knownComponentInput = 'hero_banner, cta_block, testimonial'
+      await wrapper.vm.$nextTick()
+
+      const forms = wrapper.findAll('form')
+      await forms[2]!.trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      expect(store.knownComponents).toContain('hero_banner')
+      expect(store.knownComponents).toContain('cta_block')
+      expect(store.knownComponents).toContain('testimonial')
+    })
+
+    it('trims whitespace from component slugs', async () => {
+      const store = useStore()
+      store.knownComponents = []
+
+      const wrapper = mount(ApiConfiguration)
+      getVm(wrapper).knownComponentInput = '  hero_banner  ,  cta_block  '
+      await wrapper.vm.$nextTick()
+
+      const forms = wrapper.findAll('form')
+      await forms[2]!.trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      expect(store.knownComponents).toContain('hero_banner')
+      expect(store.knownComponents).toContain('cta_block')
+    })
+
+    it('does not add duplicate known components', async () => {
+      const store = useStore()
+      store.knownComponents = ['hero_banner']
+
+      const wrapper = mount(ApiConfiguration)
+      getVm(wrapper).knownComponentInput = 'hero_banner'
+      await wrapper.vm.$nextTick()
+
+      const forms = wrapper.findAll('form')
+      await forms[2]!.trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      const heroCount = store.knownComponents.filter((c) => c === 'hero_banner').length
+      expect(heroCount).toBe(1)
+    })
+
+    it('clears the input after adding a component', async () => {
+      const wrapper = mount(ApiConfiguration)
+      getVm(wrapper).knownComponentInput = 'hero_banner'
+      await wrapper.vm.$nextTick()
+
+      const forms = wrapper.findAll('form')
+      await forms[2]!.trigger('submit')
+      await wrapper.vm.$nextTick()
+
+      expect(getVm(wrapper).knownComponentInput).toBe('')
+    })
+
+    it('renders existing known components as chips', () => {
+      const store = useStore()
+      store.knownComponents = ['hero_banner', 'cta_block']
+
+      const wrapper = mount(ApiConfiguration)
+      const chips = wrapper.findAllComponents(Chip)
+      const chipTexts = chips.map((c) => c.text())
+      expect(chipTexts.some((t) => t.includes('hero_banner'))).toBe(true)
+      expect(chipTexts.some((t) => t.includes('cta_block'))).toBe(true)
+    })
+
+    it('removes a known component when its chip is closed', async () => {
+      const store = useStore()
+      store.knownComponents = ['hero_banner', 'cta_block']
+
+      const wrapper = mount(ApiConfiguration)
+      await wrapper.vm.$nextTick()
+
+      const chips = wrapper.findAllComponents(Chip)
+      const heroBannerChip = chips.find((c) => c.text().includes('hero_banner'))!
+      // Chip emits 'remove' from its internal button click
+      await heroBannerChip.find('.chip__remove').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(store.knownComponents).not.toContain('hero_banner')
+      expect(store.knownComponents).toContain('cta_block')
     })
   })
 })

--- a/src/components/ApiConfiguration.vue
+++ b/src/components/ApiConfiguration.vue
@@ -107,6 +107,37 @@
         </ul>
         <p v-else class="api-config__empty">No collection keys configured yet</p>
       </div>
+
+      <!-- Components Section -->
+      <div class="api-config__section">
+        <h3 class="api-config__section-title">Components</h3>
+        <form @submit.prevent="addKnownComponent" novalidate class="api-config__form">
+          <TextInput
+            id="known-component-input"
+            type="text"
+            v-model="knownComponentInput"
+            root-class="api-config__input"
+            placeholder="e.g. hero_banner, cta_block, testimonial"
+          >
+            <template v-slot:label>Add Component Slug (comma-separated for multiple)</template>
+          </TextInput>
+          <Btn
+            v-if="knownComponentInput"
+            type="submit"
+            status="secondary"
+            class="api-config__button"
+            >Add</Btn
+          >
+        </form>
+        <ul v-if="store.knownComponents.length > 0" class="api-config__list">
+          <li v-for="component in store.knownComponents" :key="component">
+            <Chip removable @remove="removeKnownComponent(component)">
+              {{ component }}
+            </Chip>
+          </li>
+        </ul>
+        <p v-else class="api-config__empty">No known components configured yet</p>
+      </div>
     </div>
   </Accordion>
 </template>
@@ -123,6 +154,7 @@ import Chip from './Chip.vue'
 const store = useStore()
 const pageTypeInput = ref('')
 const collectionKeyInput = ref('')
+const knownComponentInput = ref('')
 
 const maskedToken = computed((): string => {
   if (!store.token) return ''
@@ -166,6 +198,22 @@ function addCollectionKey(): void {
 
 function removeCollectionKey(collectionKey: string): void {
   store.collectionKeys = store.collectionKeys.filter((c: string) => c !== collectionKey)
+}
+
+function addKnownComponent(): void {
+  const values = knownComponentInput.value
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v && !store.knownComponents.includes(v))
+
+  if (values.length > 0) {
+    store.knownComponents = [...store.knownComponents, ...values]
+    knownComponentInput.value = ''
+  }
+}
+
+function removeKnownComponent(component: string): void {
+  store.knownComponents = store.knownComponents.filter((c: string) => c !== component)
 }
 </script>
 

--- a/src/components/Features/ComponentsContent.spec.ts
+++ b/src/components/Features/ComponentsContent.spec.ts
@@ -1,0 +1,485 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ComponentsContent from './ComponentsContent.vue'
+import { useStore } from '@/stores/index'
+import type { ComponentsResponse } from '@/features/components'
+
+const mockAuditComponents = vi.fn()
+vi.mock('@/features/components', () => ({
+  auditComponents: (...args: unknown[]) => mockAuditComponents(...args),
+}))
+
+const mountComponent = () => {
+  return mount(ComponentsContent, {
+    global: {
+      stubs: {
+        Card: {
+          name: 'Card',
+          props: ['skeleton'],
+          template: '<div class="card" :data-skeleton="skeleton"><slot /></div>',
+        },
+        ScopeSelection: {
+          name: 'ScopeSelection',
+          props: ['disabled', 'exclude', 'ariaContext'],
+          template: '<div class="scope-selection"><slot name="legend" /></div>',
+        },
+      },
+    },
+  })
+}
+
+const makeResponse = (
+  results: ComponentsResponse['results'],
+  overrides: Partial<ComponentsResponse> = {},
+): ComponentsResponse => ({
+  success: true,
+  results,
+  totalScanned: results.reduce((acc, r) => acc + r.usages.length, 0) || 1,
+  ...overrides,
+})
+
+describe('ComponentsContent.vue', () => {
+  let store: ReturnType<typeof useStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    mockAuditComponents.mockReset()
+    store = useStore()
+    store.token = 'test-token'
+    store.knownComponents = ['hero_banner', 'cta_block']
+    store.selectedScopes = { blog: false, pageTypes: ['landing_page'], collectionKeys: [] }
+  })
+
+  describe('Guard states', () => {
+    it('shows warning when no known components configured', () => {
+      store.knownComponents = []
+      const wrapper = mountComponent()
+      expect(wrapper.text()).toContain('No known components configured')
+    })
+
+    it('does not show ScopeSelection when no known components configured', () => {
+      store.knownComponents = []
+      const wrapper = mountComponent()
+      expect(wrapper.find('.scope-selection').exists()).toBe(false)
+    })
+
+    it('does not show run button when no known components configured', () => {
+      store.knownComponents = []
+      const wrapper = mountComponent()
+      const buttons = wrapper.findAll('button')
+      const runBtn = buttons.find((b) => b.text() === 'Run Analysis')
+      expect(runBtn).toBeUndefined()
+    })
+
+    it('shows ScopeSelection when known components are configured', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.find('.scope-selection').exists()).toBe(true)
+    })
+
+    it('shows run button when known components are configured', () => {
+      const wrapper = mountComponent()
+      const buttons = wrapper.findAll('button')
+      const runBtn = buttons.find((b) => b.text().includes('Run Analysis'))
+      expect(runBtn).toBeDefined()
+    })
+
+    it('shows error and does not call api when no page types selected', async () => {
+      store.selectedScopes = { blog: false, pageTypes: [], collectionKeys: [] }
+      const wrapper = mountComponent()
+      const runBtn = wrapper.findAll('button').find((b) => b.text().includes('Run Analysis'))
+      await runBtn?.trigger('click')
+      await flushPromises()
+      expect(mockAuditComponents).not.toHaveBeenCalled()
+      expect(wrapper.text()).toContain('Please select at least one page type')
+    })
+
+    it('shows error when no token', async () => {
+      store.token = ''
+      const wrapper = mountComponent()
+      const runBtn = wrapper.findAll('button').find((b) => b.text().includes('Run Analysis'))
+      await runBtn?.trigger('click')
+      await flushPromises()
+      expect(mockAuditComponents).not.toHaveBeenCalled()
+      expect(wrapper.text()).toContain('Please enter your API token')
+    })
+  })
+
+  describe('Loading state', () => {
+    it('shows skeleton cards while loading', async () => {
+      mockAuditComponents.mockImplementation(() => new Promise(() => {})) // never resolves
+      const wrapper = mountComponent()
+      const runBtn = wrapper.findAll('button').find((b) => b.text().includes('Run Analysis'))
+      await runBtn?.trigger('click')
+      await flushPromises()
+      const skeletons = wrapper.findAll('[data-skeleton="true"]')
+      expect(skeletons.length).toBe(3)
+    })
+
+    it('renders 3 skeleton cards while loading', async () => {
+      mockAuditComponents.mockImplementation(() => new Promise(() => {}))
+      const wrapper = mountComponent()
+      const runBtn = wrapper.findAll('button').find((b) => b.text().includes('Run Analysis'))
+      await runBtn?.trigger('click')
+      await flushPromises()
+      expect(wrapper.findAll('.components-content__loading .card')).toHaveLength(3)
+    })
+  })
+
+  describe('Results rendering', () => {
+    it('renders result cards for each component', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 2,
+            usages: [
+              {
+                title: 'Home',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+              {
+                title: 'About',
+                slug: 'about',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+            ],
+          },
+          { componentSlug: 'cta_block', usageCount: 0, usages: [] },
+        ]),
+      )
+      const wrapper = mountComponent()
+      const runBtn = wrapper.findAll('button').find((b) => b.text().includes('Run Analysis'))
+      await runBtn?.trigger('click')
+      await flushPromises()
+      expect(wrapper.findAll('.components-content__result-card')).toHaveLength(2)
+    })
+
+    it('shows component slug on each result card', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 1,
+            usages: [
+              {
+                title: 'Home',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+            ],
+          },
+        ]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('hero_banner')
+    })
+
+    it('shows "0 usages" inline warning for components with 0 usages', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([{ componentSlug: 'orphan', usageCount: 0, usages: [] }]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain(
+        'No actual pages found using this component within the selected page type scopes',
+      )
+    })
+
+    it('does not show zero-usage warning for components that have usages', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 1,
+            usages: [
+              {
+                title: 'Home',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+            ],
+          },
+        ]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).not.toContain(
+        'No actual pages found using this component within the selected page type scopes',
+      )
+    })
+
+    it('shows page usage items for used components', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 1,
+            usages: [
+              {
+                title: 'My Home Page',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+            ],
+          },
+        ]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('My Home Page')
+      expect(wrapper.find('a.components-content__usage-link').exists()).toBe(false)
+    })
+
+    it('shows status badge on usage items', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 1,
+            usages: [
+              {
+                title: 'Home',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'draft',
+              },
+            ],
+          },
+        ]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      const badge = wrapper.find('.components-content__status-badge--draft')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toBe('draft')
+    })
+
+    it('shows summary with scanned pages count', async () => {
+      mockAuditComponents.mockResolvedValue({
+        success: true,
+        results: [
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 1,
+            usages: [
+              {
+                title: 'Home',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+            ],
+          },
+        ],
+        totalScanned: 5,
+      })
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('5')
+      expect(wrapper.text()).toContain('pages')
+    })
+  })
+
+  describe('Partial failure', () => {
+    it('shows partial failure warning when some scopes failed', async () => {
+      mockAuditComponents.mockResolvedValue({
+        success: true,
+        results: [],
+        totalScanned: 2,
+        failedScopes: ['bad_page'],
+      })
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('Partial failure')
+      expect(wrapper.text()).toContain('bad_page')
+    })
+
+    it('does not show partial failure warning when there are no failed scopes', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([{ componentSlug: 'hero_banner', usageCount: 0, usages: [] }]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).not.toContain('Partial failure')
+    })
+  })
+
+  describe('API error', () => {
+    it('shows error message when auditComponents returns failure', async () => {
+      mockAuditComponents.mockResolvedValue({
+        success: false,
+        results: [],
+        totalScanned: 0,
+        error: 'Something went wrong',
+      })
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('Something went wrong')
+    })
+
+    it('shows error when auditComponents throws', async () => {
+      mockAuditComponents.mockRejectedValue(new Error('Network failure'))
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.text()).toContain('Network failure')
+    })
+  })
+
+  describe('Reset', () => {
+    it('shows reset button after results are shown', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([{ componentSlug: 'hero_banner', usageCount: 0, usages: [] }]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      const resetBtn = wrapper.findAll('button').find((b) => b.text().includes('Reset'))
+      expect(resetBtn).toBeDefined()
+    })
+
+    it('clears results when reset is clicked', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 1,
+            usages: [
+              {
+                title: 'Home',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+            ],
+          },
+        ]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.findAll('.components-content__result-card').length).toBeGreaterThan(0)
+
+      const resetBtn = wrapper.findAll('button').find((b) => b.text().includes('Reset'))
+      await resetBtn?.trigger('click')
+      await flushPromises()
+      expect(wrapper.findAll('.components-content__result-card')).toHaveLength(0)
+    })
+
+    it('hides reset button before running analysis', () => {
+      const wrapper = mountComponent()
+      const resetBtn = wrapper.findAll('button').find((b) => b.text().includes('Reset'))
+      expect(resetBtn).toBeUndefined()
+    })
+  })
+
+  describe('ScopeSelection integration', () => {
+    it('passes exclude prop with blog and collectionKeys', () => {
+      const wrapper = mountComponent()
+      const scopeSel = wrapper.findComponent({ name: 'ScopeSelection' })
+      expect(scopeSel.props('exclude')).toEqual(['blog', 'collectionKeys'])
+    })
+
+    it('disables ScopeSelection after results are shown', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([{ componentSlug: 'hero_banner', usageCount: 0, usages: [] }]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      const scopeSel = wrapper.findComponent({ name: 'ScopeSelection' })
+      expect(scopeSel.props('disabled')).toBe(true)
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('renders the UtilitySection with title', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.find('.utility-section').exists()).toBe(true)
+      expect(wrapper.text()).toContain('Component Usage Audit')
+    })
+
+    it('does not render link elements on usage items', async () => {
+      mockAuditComponents.mockResolvedValue(
+        makeResponse([
+          {
+            componentSlug: 'hero_banner',
+            usageCount: 1,
+            usages: [
+              {
+                title: 'Home',
+                slug: 'home',
+                pageType: 'landing_page',
+                status: 'published',
+              },
+            ],
+          },
+        ]),
+      )
+      const wrapper = mountComponent()
+      await wrapper
+        .findAll('button')
+        .find((b) => b.text().includes('Run Analysis'))
+        ?.trigger('click')
+      await flushPromises()
+      expect(wrapper.find('a.components-content__usage-link').exists()).toBe(false)
+    })
+  })
+})

--- a/src/components/Features/ComponentsContent.vue
+++ b/src/components/Features/ComponentsContent.vue
@@ -1,0 +1,430 @@
+<template>
+  <UtilitySection
+    title="Component Usage Audit"
+    description="Identify which of your known Butter CMS components are actually used across individual pages. Unlike Butter CMS's built-in view (which shows which page types reference a component), this tool shows which individual pages use each component — so you can spot components with zero real-world page usages."
+  >
+    <!-- Info Banner -->
+    <InfoBanner status="info" class="components-content__info">
+      <strong>Page types only:</strong> Components are only available in page types — blog posts and
+      collections do not support Butter CMS components. Ensure all of your page types are added in
+      API Configuration and all are selected below for a complete analysis. A component showing
+      <strong>0 usages</strong> only reflects the selected page type scopes. <br /><br />
+      <strong>Note:</strong> Butter CMS's built-in component view shows which
+      <em>page types</em> reference a component. This tool goes further — it checks whether any
+      <em>actual pages</em> use it. A component can be registered in a page type template yet have
+      no real page usages.
+      <strong>Do not attempt to delete a component without involving a web developer</strong> to
+      verify it is not referenced in code.
+    </InfoBanner>
+
+    <!-- Guard: no known components configured -->
+    <InfoBanner v-if="store.knownComponents.length === 0" status="warning">
+      No known components configured. Add your component slugs in
+      <strong>API Configuration → Known Components</strong> above to run an analysis.
+    </InfoBanner>
+
+    <!-- Scope Selection (page types only) -->
+    <ScopeSelection
+      v-if="store.knownComponents.length > 0"
+      :disabled="hasResults"
+      :exclude="['blog', 'collectionKeys']"
+      aria-context="component audit"
+    >
+      <template #legend>Page Type Scopes</template>
+    </ScopeSelection>
+
+    <!-- Action Buttons -->
+    <Btn v-if="store.knownComponents.length > 0 && !hasResults && !isLoading" @click="executeAudit">
+      Run Analysis
+    </Btn>
+
+    <Btn v-if="hasResults" type="reset" status="tertiary" @click="resetAudit"> Reset </Btn>
+
+    <!-- Status / Error Message -->
+    <InfoBanner v-if="statusMessage && !isLoading" :status="statusType" role="alert">
+      <div>{{ statusMessage }}</div>
+    </InfoBanner>
+
+    <!-- Partial Failure Warning -->
+    <InfoBanner v-if="failedScopes.length > 0 && !isLoading" status="warning">
+      <strong>Partial failure:</strong> Failed to fetch {{ failedScopes.join(', ') }}. Results shown
+      are from successfully fetched page types only.
+    </InfoBanner>
+
+    <!-- Skeleton Loading -->
+    <div v-if="isLoading" class="components-content__loading">
+      <Card v-for="i in 3" :key="i" :skeleton="true" class="components-content__skeleton-card" />
+    </div>
+
+    <!-- Results -->
+    <div v-if="hasResults && !isLoading">
+      <!-- Summary -->
+      <div class="components-content__summary" aria-live="polite" aria-atomic="true">
+        Scanned <strong>{{ totalScanned }}</strong>
+        {{ pluralize(totalScanned, 'page', 'pages') }} across
+        <strong>{{ store.selectedScopes.pageTypes.length }}</strong>
+        {{ pluralize(store.selectedScopes.pageTypes.length, 'page type', 'page types') }}. Analysed
+        <strong>{{ results.length }}</strong>
+        {{ pluralize(results.length, 'component', 'components') }}.
+        <span v-if="orphanCount > 0" class="components-content__orphan-count">
+          {{ orphanCount }} {{ pluralize(orphanCount, 'component', 'components') }} with 0 usages.
+        </span>
+      </div>
+
+      <div class="components-content__results-list">
+        <Card
+          v-for="result in results"
+          :key="result.componentSlug"
+          v-memo="[result]"
+          class="components-content__result-card"
+          :class="{
+            'components-content__result-card--orphan': result.usageCount === 0,
+            'components-content__result-card--used': result.usageCount > 0,
+          }"
+        >
+          <div class="components-content__result-header">
+            <div class="components-content__result-header-left">
+              <div class="components-content__result-title-wrapper">
+                <code class="components-content__component-slug">{{ result.componentSlug }}</code>
+              </div>
+            </div>
+            <Chip
+              size="medium"
+              class="components-content__usage-chip"
+              :class="{
+                'components-content__usage-chip--zero': result.usageCount === 0,
+              }"
+            >
+              {{ result.usageCount }} {{ pluralize(result.usageCount, 'usage', 'usages') }}
+            </Chip>
+          </div>
+
+          <!-- Zero usage warning -->
+          <InfoBanner
+            v-if="result.usageCount === 0"
+            status="warning"
+            class="components-content__zero-warning"
+          >
+            No actual pages found using this component within the selected page type scopes. Note
+            that Butter CMS may still list this component as referenced if it appears in a page type
+            template — this tool specifically checks individual page usage. Ensure all page types
+            are selected for a complete picture.
+            <strong
+              >Do not delete this component without a web developer verifying it is not used in
+              code.</strong
+            >
+          </InfoBanner>
+
+          <!-- Usage list -->
+          <div v-if="result.usages.length > 0" class="components-content__usage-list">
+            <div
+              v-for="usage in result.usages"
+              :key="usage.slug"
+              class="components-content__usage-item"
+            >
+              <div class="components-content__usage-item-content">
+                <span
+                  v-if="usage.status"
+                  class="components-content__status-badge"
+                  :class="`components-content__status-badge--${usage.status}`"
+                  >{{ usage.status }}</span
+                >
+                <span class="components-content__usage-title">{{ usage.title }}</span>
+                <span class="components-content__usage-meta">
+                  <span class="components-content__usage-slug">{{ usage.slug }}</span>
+                  <span class="components-content__usage-page-type">({{ usage.pageType }})</span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  </UtilitySection>
+</template>
+
+<script lang="ts" setup>
+import { ref, shallowRef, computed, defineAsyncComponent } from 'vue'
+import { useStore } from '@/stores/index'
+import UtilitySection from '../UtilitySection.vue'
+import ScopeSelection from '../ScopeSelection.vue'
+import Btn from '../Btn.vue'
+import InfoBanner from '../InfoBanner.vue'
+import Chip from '../Chip.vue'
+import { auditComponents } from '@/features/components'
+import type { ComponentsResponse } from '@/features/components'
+
+const Card = defineAsyncComponent(() => import('../Card.vue'))
+
+const store = useStore()
+
+const isLoading = ref(false)
+const statusMessage = ref('')
+const statusType = ref<'info' | 'success' | 'error' | 'warning'>('info')
+// Use shallowRef for large results array - replaced wholesale, never mutated deeply
+const results = shallowRef<ComponentsResponse['results']>([])
+const failedScopes = ref<string[]>([])
+const totalScanned = ref(0)
+
+const hasResults = computed(() => results.value.length > 0)
+const orphanCount = computed(() => results.value.filter((r) => r.usageCount === 0).length)
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return count === 1 ? singular : plural
+}
+
+function resetAudit(): void {
+  results.value = []
+  failedScopes.value = []
+  statusMessage.value = ''
+  totalScanned.value = 0
+}
+
+function setStatus(
+  message: string,
+  type: 'info' | 'success' | 'error' | 'warning' = 'info',
+  loading = false,
+): void {
+  statusMessage.value = message
+  statusType.value = type
+  isLoading.value = loading
+}
+
+async function executeAudit(): Promise<void> {
+  const token = store.token
+
+  results.value = []
+  failedScopes.value = []
+  statusMessage.value = ''
+  totalScanned.value = 0
+
+  if (!token) {
+    setStatus('Please enter your API token in the configuration above', 'error')
+    return
+  }
+
+  if (store.knownComponents.length === 0) {
+    setStatus(
+      'No known components configured. Add component slugs in API Configuration above.',
+      'error',
+    )
+    return
+  }
+
+  if (store.selectedScopes.pageTypes.length === 0) {
+    setStatus('Please select at least one page type scope to run the analysis.', 'error')
+    return
+  }
+
+  isLoading.value = true
+  setStatus('Scanning pages for component usage...', 'info', true)
+
+  try {
+    const response = await auditComponents(
+      token,
+      store.includePreview,
+      store.selectedScopes.pageTypes,
+      store.knownComponents,
+    )
+
+    if (!response.success) {
+      setStatus(response.error ?? 'Analysis failed', 'error')
+      return
+    }
+
+    totalScanned.value = response.totalScanned
+    failedScopes.value = response.failedScopes ?? []
+    results.value = response.results
+
+    const usedCount = response.results.filter((r) => r.usageCount > 0).length
+    const unusedCount = response.results.length - usedCount
+    setStatus(
+      `Analysis complete. ${usedCount} ${pluralize(usedCount, 'component', 'components')} in use, ${unusedCount} with 0 usages.`,
+      'success',
+    )
+  } catch (error) {
+    setStatus(`Error: ${(error as Error).message}`, 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.components-content {
+  &__info {
+    margin-bottom: var(--space-6);
+  }
+
+  &__loading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    margin-top: var(--space-6);
+  }
+
+  &__skeleton-card {
+    margin-bottom: 0;
+  }
+
+  &__summary {
+    background-color: var(--bg-primary);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    font-weight: 500;
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-relaxed);
+    position: sticky;
+    top: var(--space-4);
+    z-index: 10;
+    box-shadow: var(--shadow-sm);
+    margin-bottom: var(--space-6);
+  }
+
+  &__orphan-count {
+    color: var(--color-warning, #9a6700);
+    font-weight: 600;
+  }
+
+  &__results-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  &__result-card {
+    border-left: 3px solid var(--accent-blue);
+
+    &--orphan {
+      border-left-color: var(--color-warning-border, #e6a817);
+    }
+
+    &--used {
+      border-left-color: var(--accent-blue);
+    }
+  }
+
+  &__result-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-4);
+    margin-bottom: var(--space-3);
+    flex-wrap: wrap;
+  }
+
+  &__result-header-left {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__result-title-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+
+  &__component-slug {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    font-family: monospace;
+    color: var(--text-primary);
+    word-break: break-word;
+    background-color: var(--bg-secondary);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+  }
+
+  &__usage-chip {
+    flex-shrink: 0;
+
+    &--zero {
+      // Override chip with orange/warning tones for zero usage
+      background-color: #fff7ca !important;
+      color: #726a3a !important;
+      border-color: #e6ce72 !important;
+    }
+  }
+
+  &__zero-warning {
+    margin-bottom: var(--space-3);
+  }
+
+  &__usage-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    margin-top: var(--space-2);
+  }
+
+  &__usage-item {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: var(--space-4);
+    padding: var(--space-3);
+    background-color: var(--bg-secondary);
+    border-radius: var(--radius-sm);
+    flex-wrap: wrap;
+  }
+
+  &__usage-item-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    flex: 1;
+    min-width: 0;
+  }
+
+  // Status badge colours matching AuditContent
+  &__status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: capitalize;
+    letter-spacing: 0.03em;
+
+    &--published {
+      color: #34824d;
+      background-color: #d4f4d2;
+    }
+
+    &--draft {
+      color: #726a3a;
+      background-color: #fff7ca;
+    }
+
+    &--scheduled {
+      color: #31459a;
+      background-color: #eff1ff;
+    }
+  }
+
+  &__usage-title {
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    color: var(--text-primary);
+  }
+
+  &__usage-meta {
+    display: flex;
+    gap: var(--space-2);
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  &__usage-slug {
+    font-family: monospace;
+  }
+
+  &__usage-page-type {
+    color: var(--text-tertiary, var(--text-secondary));
+  }
+}
+</style>

--- a/src/components/ScopeSelection.spec.ts
+++ b/src/components/ScopeSelection.spec.ts
@@ -350,4 +350,110 @@ describe('ScopeSelection.vue', () => {
       expect(store.selectedScopes.pageTypes).toEqual(['blog_post'])
     })
   })
+
+  describe('Exclude Prop', () => {
+    it('hides blog checkbox when exclude includes "blog"', () => {
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: ['blog'] },
+      })
+      // Blog checkbox is the first checkbox - it should not exist when excluded
+      const blogLabel = wrapper
+        .findAll('label')
+        .find((l) => l.text().toLowerCase().includes('blog'))
+      expect(blogLabel).toBeUndefined()
+    })
+
+    it('shows blog checkbox when exclude does not include "blog"', () => {
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: ['collectionKeys'] },
+      })
+      const blogLabel = wrapper
+        .findAll('label')
+        .find((l) => l.text().toLowerCase().includes('blog'))
+      expect(blogLabel).toBeDefined()
+    })
+
+    it('shows blog checkbox when exclude prop is not provided', () => {
+      const wrapper = mount(ScopeSelection)
+      const blogLabel = wrapper
+        .findAll('label')
+        .find((l) => l.text().toLowerCase().includes('blog'))
+      expect(blogLabel).toBeDefined()
+    })
+
+    it('hides collection keys group when exclude includes "collectionKeys"', () => {
+      const store = useStore()
+      store.collectionKeys = ['products', 'customers']
+
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: ['collectionKeys'] },
+      })
+
+      const allText = wrapper.text()
+      expect(allText).not.toContain('Collection Keys')
+    })
+
+    it('shows collection keys group when exclude does not include "collectionKeys"', () => {
+      const store = useStore()
+      store.collectionKeys = ['products']
+
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: ['blog'] },
+      })
+
+      expect(wrapper.text()).toContain('Collection Keys')
+    })
+
+    it('hides both blog and collection keys when both are excluded', () => {
+      const store = useStore()
+      store.collectionKeys = ['products']
+
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: ['blog', 'collectionKeys'] },
+      })
+
+      const blogLabel = wrapper
+        .findAll('label')
+        .find((l) => l.text().toLowerCase().includes('blog'))
+      expect(blogLabel).toBeUndefined()
+      expect(wrapper.text()).not.toContain('Collection Keys')
+    })
+
+    it('shows page types even when blog and collectionKeys are excluded', () => {
+      const store = useStore()
+      store.pageTypes = ['landing_page']
+
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: ['blog', 'collectionKeys'] },
+      })
+
+      expect(wrapper.text()).toContain('Page Types')
+      expect(wrapper.text()).toContain('landing_page')
+    })
+
+    it('shows page-types-only empty message when blog and collectionKeys excluded and no page types', () => {
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: ['blog', 'collectionKeys'] },
+      })
+
+      const emptyMessage = wrapper.find('.scope-selection__empty-scopes')
+      expect(emptyMessage.exists()).toBe(true)
+      expect(emptyMessage.text()).toContain('No page types configured')
+    })
+
+    it('has no effect when exclude is an empty array', () => {
+      const store = useStore()
+      store.collectionKeys = ['products']
+
+      const wrapper = mount(ScopeSelection, {
+        props: { exclude: [] },
+      })
+
+      const blogLabel = wrapper
+        .findAll('label')
+        .find((l) => l.text().toLowerCase().includes('blog'))
+      expect(blogLabel).toBeDefined()
+      expect(wrapper.text()).toContain('Collection Keys')
+    })
+  })
 })

--- a/src/components/ScopeSelection.vue
+++ b/src/components/ScopeSelection.vue
@@ -5,7 +5,7 @@
     </legend>
 
     <!-- Blog Checkbox -->
-    <label class="scope-selection__checkbox-option">
+    <label v-if="!exclude?.includes('blog')" class="scope-selection__checkbox-option">
       <input
         type="checkbox"
         v-model="includeBlog"
@@ -38,7 +38,10 @@
     </div>
 
     <!-- Collection Keys Checkboxes -->
-    <div v-if="store.collectionKeys.length > 0" class="scope-selection__scope-group">
+    <div
+      v-if="!exclude?.includes('collectionKeys') && store.collectionKeys.length > 0"
+      class="scope-selection__scope-group"
+    >
       <div class="scope-selection__scope-group-title">Collection Keys</div>
       <div class="scope-selection__scope-options">
         <label
@@ -61,10 +64,18 @@
 
     <!-- Message if no page types or collection keys configured -->
     <div
-      v-if="store.pageTypes.length === 0 && store.collectionKeys.length === 0"
+      v-if="
+        store.pageTypes.length === 0 &&
+        (exclude?.includes('collectionKeys') || store.collectionKeys.length === 0)
+      "
       class="scope-selection__empty-scopes"
     >
-      <p>No page types or collection keys configured. Configure them in API Configuration above.</p>
+      <p v-if="exclude?.includes('blog') && exclude?.includes('collectionKeys')">
+        No page types configured. Add them in API Configuration above.
+      </p>
+      <p v-else>
+        No page types or collection keys configured. Configure them in API Configuration above.
+      </p>
     </div>
   </fieldset>
 </template>
@@ -76,6 +87,7 @@ import { useStore } from '@/stores/index'
 defineProps<{
   disabled?: boolean
   ariaContext?: string
+  exclude?: ('blog' | 'collectionKeys')[]
 }>()
 
 const store = useStore()

--- a/src/components/TabPanel.spec.ts
+++ b/src/components/TabPanel.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, type WritableComputedRef } from 'vue'
+import TabPanel from './TabPanel.vue'
+
+const createWrapper = (
+  props: { label: string; icon?: string; index: number },
+  activeTabIndex = 0,
+) => {
+  const activeTabIndexRef = ref(activeTabIndex) as unknown as WritableComputedRef<number>
+  const registerTabPanel = vi.fn()
+  const unregisterTabPanel = vi.fn()
+
+  const wrapper = mount(TabPanel, {
+    props,
+    global: {
+      provide: {
+        activeTabIndex: activeTabIndexRef,
+        registerTabPanel,
+        unregisterTabPanel,
+      },
+    },
+    slots: {
+      default: '<p>Panel content</p>',
+    },
+  })
+
+  return { wrapper, activeTabIndexRef, registerTabPanel, unregisterTabPanel }
+}
+
+describe('TabPanel.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Lifecycle', () => {
+    it('registers itself on mount', () => {
+      const { registerTabPanel } = createWrapper({ label: 'Search', index: 0 })
+      expect(registerTabPanel).toHaveBeenCalledOnce()
+      expect(registerTabPanel).toHaveBeenCalledWith({ label: 'Search', icon: undefined, index: 0 })
+    })
+
+    it('registers with icon when provided', () => {
+      const { registerTabPanel } = createWrapper({ label: 'Audit', icon: '⚠️', index: 1 })
+      expect(registerTabPanel).toHaveBeenCalledWith({ label: 'Audit', icon: '⚠️', index: 1 })
+    })
+
+    it('unregisters itself on unmount', () => {
+      const { wrapper, unregisterTabPanel } = createWrapper({ label: 'Search', index: 0 })
+      wrapper.unmount()
+      expect(unregisterTabPanel).toHaveBeenCalledOnce()
+      expect(unregisterTabPanel).toHaveBeenCalledWith(0)
+    })
+
+    it('unregisters with correct index', () => {
+      const { wrapper, unregisterTabPanel } = createWrapper({ label: 'Components', index: 2 })
+      wrapper.unmount()
+      expect(unregisterTabPanel).toHaveBeenCalledWith(2)
+    })
+  })
+
+  describe('Rendering', () => {
+    it('renders panel content when active', () => {
+      const { wrapper } = createWrapper({ label: 'Search', index: 0 }, 0)
+      expect(wrapper.find('[role="tabpanel"]').exists()).toBe(true)
+      expect(wrapper.find('[role="tabpanel"]').text()).toContain('Panel content')
+    })
+
+    it('does not render when inactive', () => {
+      const { wrapper } = createWrapper({ label: 'Audit', index: 1 }, 0)
+      expect(wrapper.find('[role="tabpanel"]').exists()).toBe(false)
+    })
+
+    it('renders when its index matches activeTabIndex', () => {
+      const { wrapper } = createWrapper({ label: 'Components', index: 2 }, 2)
+      expect(wrapper.find('[role="tabpanel"]').exists()).toBe(true)
+    })
+
+    it('shows/hides based on activeTabIndex changes', async () => {
+      const activeTabIndexRef = ref(0) as unknown as WritableComputedRef<number>
+      const wrapper = mount(TabPanel, {
+        props: { label: 'Audit', index: 1 },
+        global: {
+          provide: {
+            activeTabIndex: activeTabIndexRef,
+            registerTabPanel: vi.fn(),
+            unregisterTabPanel: vi.fn(),
+          },
+        },
+        slots: { default: '<p>Audit content</p>' },
+      })
+
+      expect(wrapper.find('[role="tabpanel"]').exists()).toBe(false)
+
+      activeTabIndexRef.value = 1
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[role="tabpanel"]').exists()).toBe(true)
+    })
+  })
+
+  describe('ARIA Attributes', () => {
+    it('sets role="tabpanel" on the panel div', () => {
+      const { wrapper } = createWrapper({ label: 'Search', index: 0 }, 0)
+      const panel = wrapper.find('[role="tabpanel"]')
+      expect(panel.attributes('role')).toBe('tabpanel')
+    })
+
+    it('sets correct id based on index', () => {
+      const { wrapper } = createWrapper({ label: 'Search', index: 0 }, 0)
+      const panel = wrapper.find('[role="tabpanel"]')
+      expect(panel.attributes('id')).toBe('tab-panel-0')
+    })
+
+    it('sets correct id for non-zero index', () => {
+      const { wrapper } = createWrapper({ label: 'Audit', index: 1 }, 1)
+      const panel = wrapper.find('[role="tabpanel"]')
+      expect(panel.attributes('id')).toBe('tab-panel-1')
+    })
+
+    it('sets aria-labelledby referencing the corresponding tab button', () => {
+      const { wrapper } = createWrapper({ label: 'Search', index: 0 }, 0)
+      const panel = wrapper.find('[role="tabpanel"]')
+      expect(panel.attributes('aria-labelledby')).toBe('tab-0')
+    })
+
+    it('sets correct aria-labelledby for non-zero index', () => {
+      const { wrapper } = createWrapper({ label: 'Components', index: 2 }, 2)
+      const panel = wrapper.find('[role="tabpanel"]')
+      expect(panel.attributes('aria-labelledby')).toBe('tab-2')
+    })
+  })
+
+  describe('Props', () => {
+    it('accepts label prop', () => {
+      const { registerTabPanel } = createWrapper({ label: 'My Tab', index: 0 })
+      expect(registerTabPanel).toHaveBeenCalledWith(expect.objectContaining({ label: 'My Tab' }))
+    })
+
+    it('accepts optional icon prop', () => {
+      const { registerTabPanel } = createWrapper({ label: 'Search', icon: '🔍', index: 0 })
+      expect(registerTabPanel).toHaveBeenCalledWith(expect.objectContaining({ icon: '🔍' }))
+    })
+
+    it('passes undefined when icon is not provided', () => {
+      const { registerTabPanel } = createWrapper({ label: 'Search', index: 0 })
+      expect(registerTabPanel).toHaveBeenCalledWith(expect.objectContaining({ icon: undefined }))
+    })
+
+    it('accepts index prop and uses it for panel id', () => {
+      const { wrapper } = createWrapper({ label: 'Last', index: 5 }, 5)
+      expect(wrapper.find('[role="tabpanel"]').attributes('id')).toBe('tab-panel-5')
+    })
+  })
+
+  describe('Slot', () => {
+    it('renders default slot content', () => {
+      const activeTabIndexRef = ref(0) as unknown as WritableComputedRef<number>
+      const wrapper = mount(TabPanel, {
+        props: { label: 'Search', index: 0 },
+        global: {
+          provide: {
+            activeTabIndex: activeTabIndexRef,
+            registerTabPanel: vi.fn(),
+            unregisterTabPanel: vi.fn(),
+          },
+        },
+        slots: { default: '<span class="custom-content">Custom slot</span>' },
+      })
+
+      expect(wrapper.find('.custom-content').exists()).toBe(true)
+      expect(wrapper.find('.custom-content').text()).toBe('Custom slot')
+    })
+  })
+})

--- a/src/components/TabPanel.vue
+++ b/src/components/TabPanel.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { inject, computed, onMounted, onUnmounted, type WritableComputedRef } from 'vue'
+
+const props = defineProps<{
+  label: string
+  icon?: string
+  index: number
+}>()
+
+const activeTabIndex = inject<WritableComputedRef<number>>('activeTabIndex')!
+const registerTabPanel =
+  inject<(meta: { label: string; icon?: string; index: number }) => void>('registerTabPanel')!
+const unregisterTabPanel = inject<(index: number) => void>('unregisterTabPanel')!
+
+const panelId = computed(() => `tab-panel-${props.index}`)
+const isActive = computed(() => activeTabIndex.value === props.index)
+
+onMounted(() => {
+  registerTabPanel({ label: props.label, icon: props.icon, index: props.index })
+})
+
+onUnmounted(() => {
+  unregisterTabPanel(props.index)
+})
+</script>
+
+<template>
+  <div :id="panelId" role="tabpanel" :aria-labelledby="`tab-${index}`" v-if="isActive">
+    <slot />
+  </div>
+</template>

--- a/src/components/Tabs.spec.ts
+++ b/src/components/Tabs.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, VueWrapper } from '@vue/test-utils'
-import { createPinia } from 'pinia'
+import { createPinia, setActivePinia } from 'pinia'
 import Tabs from './Tabs.vue'
-import Tab from './Tab.vue'
+import TabPanel from './TabPanel.vue'
 
 describe('Tabs', () => {
   let wrapper: VueWrapper
@@ -10,25 +10,22 @@ describe('Tabs', () => {
   const createWrapper = () => {
     return mount(Tabs, {
       slots: {
-        tabs: `
-          <Tab label="First" icon="🔍" panel-id="panel-1" :index="0" />
-          <Tab label="Second" icon="⚠️" panel-id="panel-2" :index="1" />
-          <Tab label="Third" panel-id="panel-3" :index="2" />
-        `,
-        panels: `
-          <div id="panel-1" role="tabpanel">Panel 1 content</div>
-          <div id="panel-2" role="tabpanel">Panel 2 content</div>
-          <div id="panel-3" role="tabpanel">Panel 3 content</div>
+        default: `
+          <TabPanel label="First" icon="🔍" :index="0">Panel 1 content</TabPanel>
+          <TabPanel label="Second" icon="⚠️" :index="1">Panel 2 content</TabPanel>
+          <TabPanel label="Third" :index="2">Panel 3 content</TabPanel>
         `,
       },
       global: {
-        components: { Tab },
+        components: { TabPanel },
         plugins: [createPinia()],
       },
     })
   }
 
   beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
     wrapper = createWrapper()
   })
 
@@ -47,146 +44,201 @@ describe('Tabs', () => {
       expect(wrapper.find('.tabs__panels').exists()).toBe(true)
     })
 
-    it('should render slot content for tabs and panels', () => {
-      expect(wrapper.findAllComponents(Tab)).toHaveLength(3)
-      expect(wrapper.findAll('[role="tabpanel"]')).toHaveLength(3)
+    it('should render a tab button for each registered TabPanel', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      expect(buttons).toHaveLength(3)
+    })
+
+    it('should render tab labels', async () => {
+      await wrapper.vm.$nextTick()
+      const labels = wrapper.findAll('.tab__label')
+      expect(labels[0]!.text()).toBe('First')
+      expect(labels[1]!.text()).toBe('Second')
+      expect(labels[2]!.text()).toBe('Third')
+    })
+
+    it('should render tab icon when provided', async () => {
+      await wrapper.vm.$nextTick()
+      const icons = wrapper.findAll('.tab__icon')
+      expect(icons).toHaveLength(2) // First and Second have icons
+      expect(icons[0]!.text()).toBe('🔍')
+      expect(icons[1]!.text()).toBe('⚠️')
+    })
+
+    it('should not render icon element when no icon provided', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      // Third tab has no icon
+      expect(buttons[2]!.find('.tab__icon').exists()).toBe(false)
     })
   })
 
   describe('Keyboard Navigation', () => {
     it('should navigate to next tab with ArrowRight', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
-      const tabs = wrapper.findAllComponents(Tab)
 
-      // Verify first tab is initially active
-      expect(tabs[0]!.find('button').attributes('aria-selected')).toBe('true')
+      // First tab should be active initially
+      const buttons = wrapper.findAll('[role="tab"]')
+      expect(buttons[0]!.attributes('aria-selected')).toBe('true')
 
-      // Trigger ArrowRight
       await tablist.trigger('keydown', { key: 'ArrowRight' })
       await wrapper.vm.$nextTick()
 
-      // Second tab should now be active
-      expect(tabs[1]!.find('button').attributes('aria-selected')).toBe('true')
+      expect(buttons[1]!.attributes('aria-selected')).toBe('true')
     })
 
     it('should navigate to previous tab with ArrowLeft', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
-      const tabs = wrapper.findAllComponents(Tab)
+      const buttons = wrapper.findAll('[role="tab"]')
 
       // Click second tab to make it active
-      await tabs[1]!.find('button').trigger('click')
+      await buttons[1]!.trigger('click')
       await wrapper.vm.$nextTick()
+      expect(buttons[1]!.attributes('aria-selected')).toBe('true')
 
-      // Trigger ArrowLeft
       await tablist.trigger('keydown', { key: 'ArrowLeft' })
       await wrapper.vm.$nextTick()
 
-      // First tab should now be active
-      expect(tabs[0]!.find('button').attributes('aria-selected')).toBe('true')
+      expect(buttons[0]!.attributes('aria-selected')).toBe('true')
     })
 
     it('should wrap to last tab when ArrowLeft on first tab', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
-      const tabs = wrapper.findAllComponents(Tab)
+      const buttons = wrapper.findAll('[role="tab"]')
 
       // First tab is active by default
-      expect(tabs[0]!.find('button').attributes('aria-selected')).toBe('true')
-
-      // Trigger ArrowLeft
       await tablist.trigger('keydown', { key: 'ArrowLeft' })
       await wrapper.vm.$nextTick()
 
-      // Should wrap to last tab (index 2)
-      expect(tabs[2]!.find('button').attributes('aria-selected')).toBe('true')
+      expect(buttons[2]!.attributes('aria-selected')).toBe('true')
     })
 
     it('should wrap to first tab when ArrowRight on last tab', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
-      const tabs = wrapper.findAllComponents(Tab)
+      const buttons = wrapper.findAll('[role="tab"]')
 
-      // Click last tab to make it active
-      await tabs[2]!.find('button').trigger('click')
+      // Click last tab
+      await buttons[2]!.trigger('click')
       await wrapper.vm.$nextTick()
 
-      // Trigger ArrowRight
       await tablist.trigger('keydown', { key: 'ArrowRight' })
       await wrapper.vm.$nextTick()
 
-      // Should wrap to first tab
-      expect(tabs[0]!.find('button').attributes('aria-selected')).toBe('true')
+      expect(buttons[0]!.attributes('aria-selected')).toBe('true')
     })
 
     it('should navigate to first tab with Home key', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
-      const tabs = wrapper.findAllComponents(Tab)
+      const buttons = wrapper.findAll('[role="tab"]')
 
-      // Click middle tab to make it active
-      await tabs[1]!.find('button').trigger('click')
+      // Click second tab
+      await buttons[1]!.trigger('click')
       await wrapper.vm.$nextTick()
 
-      // Trigger Home
       await tablist.trigger('keydown', { key: 'Home' })
       await wrapper.vm.$nextTick()
 
-      expect(tabs[0]!.find('button').attributes('aria-selected')).toBe('true')
+      expect(buttons[0]!.attributes('aria-selected')).toBe('true')
     })
 
     it('should navigate to last tab with End key', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
-      const tabs = wrapper.findAllComponents(Tab)
+      const buttons = wrapper.findAll('[role="tab"]')
 
-      // First tab is active by default
-      expect(tabs[0]!.find('button').attributes('aria-selected')).toBe('true')
-
-      // Trigger End
       await tablist.trigger('keydown', { key: 'End' })
       await wrapper.vm.$nextTick()
 
-      expect(tabs[2]!.find('button').attributes('aria-selected')).toBe('true')
+      expect(buttons[2]!.attributes('aria-selected')).toBe('true')
     })
 
-    it('should prevent default behavior on navigation keys', async () => {
+    it('should prevent default behavior on ArrowRight', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
-      const event = new KeyboardEvent('keydown', { key: 'ArrowRight' })
+      const event = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
       const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
-
-      await tablist.element.dispatchEvent(event)
-
+      tablist.element.dispatchEvent(event)
       expect(preventDefaultSpy).toHaveBeenCalled()
     })
   })
 
   describe('Accessibility', () => {
-    it('should have correct ARIA roles', () => {
+    it('should have correct ARIA roles on tablist', async () => {
+      await wrapper.vm.$nextTick()
       const tablist = wrapper.find('[role="tablist"]')
       expect(tablist.exists()).toBe(true)
     })
 
-    it('should maintain proper tab/panel relationship via aria-controls', () => {
-      const tabs = wrapper.findAllComponents(Tab)
-      const panels = wrapper.findAll('[role="tabpanel"]')
+    it('tab buttons should have role="tab"', async () => {
+      await wrapper.vm.$nextTick()
+      const tabs = wrapper.findAll('[role="tab"]')
+      expect(tabs.length).toBe(3)
+    })
 
-      tabs.forEach((tab, index) => {
-        const panelId = panels[index]!.attributes('id')
-        expect(tab.props('panelId')).toBe(panelId)
+    it('first tab should be selected by default', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      expect(buttons[0]!.attributes('aria-selected')).toBe('true')
+    })
+
+    it('inactive tabs should have aria-selected="false"', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      expect(buttons[1]!.attributes('aria-selected')).toBe('false')
+      expect(buttons[2]!.attributes('aria-selected')).toBe('false')
+    })
+
+    it('active tab should have tabindex="0", inactive tabs tabindex="-1"', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      expect(buttons[0]!.attributes('tabindex')).toBe('0')
+      expect(buttons[1]!.attributes('tabindex')).toBe('-1')
+    })
+
+    it('tab icons should have aria-hidden="true"', async () => {
+      await wrapper.vm.$nextTick()
+      const icons = wrapper.findAll('.tab__icon')
+      icons.forEach((icon) => {
+        expect(icon.attributes('aria-hidden')).toBe('true')
       })
     })
   })
 
   describe('State Management', () => {
-    it('should start with first tab active by default', () => {
-      const tabs = wrapper.findAllComponents(Tab)
-      expect(tabs[0]!.find('button').attributes('aria-selected')).toBe('true')
+    it('should start with first tab active by default', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      expect(buttons[0]!.attributes('aria-selected')).toBe('true')
     })
 
-    it('should update active tab when tab is clicked', async () => {
-      const tabs = wrapper.findAllComponents(Tab)
+    it('should update active tab when tab button is clicked', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
 
-      // Click second tab
-      await tabs[1]!.find('button').trigger('click')
+      await buttons[1]!.trigger('click')
       await wrapper.vm.$nextTick()
 
-      expect(tabs[1]!.find('button').attributes('aria-selected')).toBe('true')
+      expect(buttons[1]!.attributes('aria-selected')).toBe('true')
+      expect(buttons[0]!.attributes('aria-selected')).toBe('false')
+    })
+
+    it('should show first panel content by default', async () => {
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[role="tabpanel"]').text()).toContain('Panel 1 content')
+    })
+
+    it('should show second panel when second tab is clicked', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      await buttons[1]!.trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('[role="tabpanel"]').text()).toContain('Panel 2 content')
     })
   })
 
@@ -197,9 +249,11 @@ describe('Tabs', () => {
       expect(wrapper.find('.tabs__panels').exists()).toBe(true)
     })
 
-    it('should have gap between tabs', () => {
-      const tablist = wrapper.find('.tabs__list')
-      expect(tablist.attributes('style')).toBeUndefined() // Uses CSS custom properties
+    it('should apply tab--active class to active tab', async () => {
+      await wrapper.vm.$nextTick()
+      const buttons = wrapper.findAll('[role="tab"]')
+      expect(buttons[0]!.classes()).toContain('tab--active')
+      expect(buttons[1]!.classes()).not.toContain('tab--active')
     })
   })
 })

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,13 +1,33 @@
 <script setup lang="ts">
-import { ref, provide, onMounted, onUnmounted, computed, type WritableComputedRef } from 'vue'
+import { ref, provide, computed, onMounted, onUnmounted, type WritableComputedRef } from 'vue'
 import { useStore } from '@/stores'
+
+interface TabMeta {
+  label: string
+  icon?: string
+  index: number
+}
 
 const store = useStore()
 const tabsRef = ref<HTMLDivElement | null>(null)
-const tabButtons = ref<HTMLButtonElement[]>([])
 
-// Create a writable computed that directly accesses the store
-// This acts as a proper Ref<number> for provide/inject
+// Registry of TabPanel components' metadata
+const tabMetas = ref<TabMeta[]>([])
+
+// Sorted tab list for rendering buttons in order
+const sortedTabMetas = computed(() => [...tabMetas.value].sort((a, b) => a.index - b.index))
+
+// Keep refs to rendered tab buttons keyed by index (for focus management)
+const tabButtonMap = ref(new Map<number, HTMLButtonElement>())
+
+// Ordered button list derived from sorted metas
+const sortedTabButtons = computed(() =>
+  sortedTabMetas.value
+    .map((meta) => tabButtonMap.value.get(meta.index))
+    .filter((el): el is HTMLButtonElement => el != null),
+)
+
+// Active tab index backed by Pinia store
 const activeTabIndexRef: WritableComputedRef<number> = computed({
   get: () => store.activeTabIndex,
   set: (val: number) => {
@@ -15,48 +35,78 @@ const activeTabIndexRef: WritableComputedRef<number> = computed({
   },
 })
 
-// Expose activeTabIndex for use in template slots
 defineExpose({
   activeTabIndex: activeTabIndexRef,
 })
 
 provide('activeTabIndex', activeTabIndexRef)
-provide('registerTab', (tabElement: HTMLButtonElement) => {
-  if (!tabButtons.value.includes(tabElement)) {
-    tabButtons.value.push(tabElement)
-  }
-})
-provide('unregisterTab', (tabElement: HTMLButtonElement) => {
-  const index = tabButtons.value.indexOf(tabElement)
-  if (index > -1) {
-    tabButtons.value.splice(index, 1)
+
+// Provide registration functions for TabPanel components
+provide('registerTabPanel', (meta: TabMeta) => {
+  if (!tabMetas.value.some((t) => t.index === meta.index)) {
+    tabMetas.value = [...tabMetas.value, meta]
   }
 })
 
+provide('unregisterTabPanel', (index: number) => {
+  tabMetas.value = tabMetas.value.filter((t) => t.index !== index)
+  tabButtonMap.value.delete(index)
+})
+
+// Button ref setter used in v-for
+function setTabButtonRef(el: Element | null | undefined, index: number): void {
+  if (el instanceof HTMLButtonElement) {
+    tabButtonMap.value.set(index, el)
+  } else {
+    tabButtonMap.value.delete(index)
+  }
+}
+
+function handleTabClick(index: number): void {
+  activeTabIndexRef.value = index
+}
+
+function handleTabKeydown(event: KeyboardEvent, index: number): void {
+  if (event.key === ' ' || event.key === 'Enter') {
+    event.preventDefault()
+    activeTabIndexRef.value = index
+  }
+}
+
 const handleKeydown = (event: KeyboardEvent) => {
-  const currentIndex = activeTabIndexRef.value
-  const lastIndex = tabButtons.value.length - 1
+  const buttons = sortedTabButtons.value
+  if (buttons.length === 0) return
+
+  // Find current position in sorted order by active tab index
+  const currentPosition = sortedTabMetas.value.findIndex(
+    (meta) => meta.index === activeTabIndexRef.value,
+  )
+  if (currentPosition === -1) return
+
+  const lastIndex = buttons.length - 1
 
   switch (event.key) {
     case 'ArrowLeft':
       event.preventDefault()
-      activeTabIndexRef.value = currentIndex > 0 ? currentIndex - 1 : lastIndex
-      tabButtons.value[activeTabIndexRef.value]?.focus()
+      activeTabIndexRef.value =
+        sortedTabMetas.value[currentPosition > 0 ? currentPosition - 1 : lastIndex]!.index
+      buttons[currentPosition > 0 ? currentPosition - 1 : lastIndex]?.focus()
       break
     case 'ArrowRight':
       event.preventDefault()
-      activeTabIndexRef.value = currentIndex < lastIndex ? currentIndex + 1 : 0
-      tabButtons.value[activeTabIndexRef.value]?.focus()
+      activeTabIndexRef.value =
+        sortedTabMetas.value[currentPosition < lastIndex ? currentPosition + 1 : 0]!.index
+      buttons[currentPosition < lastIndex ? currentPosition + 1 : 0]?.focus()
       break
     case 'Home':
       event.preventDefault()
-      activeTabIndexRef.value = 0
-      tabButtons.value[0]?.focus()
+      activeTabIndexRef.value = sortedTabMetas.value[0]!.index
+      buttons[0]?.focus()
       break
     case 'End':
       event.preventDefault()
-      activeTabIndexRef.value = lastIndex
-      tabButtons.value[lastIndex]?.focus()
+      activeTabIndexRef.value = sortedTabMetas.value[lastIndex]!.index
+      buttons[lastIndex]?.focus()
       break
   }
 }
@@ -73,10 +123,27 @@ onUnmounted(() => {
 <template>
   <div class="tabs">
     <div ref="tabsRef" role="tablist" class="tabs__list">
-      <slot name="tabs" />
+      <button
+        v-for="tab in sortedTabMetas"
+        :key="tab.index"
+        :id="`tab-${tab.index}`"
+        :ref="(el) => setTabButtonRef(el as Element | null, tab.index)"
+        type="button"
+        role="tab"
+        :aria-selected="activeTabIndexRef === tab.index"
+        :aria-controls="`tab-panel-${tab.index}`"
+        :tabindex="activeTabIndexRef === tab.index ? 0 : -1"
+        class="tab"
+        :class="{ 'tab--active': activeTabIndexRef === tab.index }"
+        @click="handleTabClick(tab.index)"
+        @keydown="handleTabKeydown($event, tab.index)"
+      >
+        <span v-if="tab.icon" class="tab__icon" aria-hidden="true">{{ tab.icon }}</span>
+        <span class="tab__label">{{ tab.label }}</span>
+      </button>
     </div>
     <div class="tabs__panels">
-      <slot name="panels" :activeTabIndex="store.activeTabIndex" />
+      <slot />
     </div>
   </div>
 </template>
@@ -94,6 +161,59 @@ onUnmounted(() => {
 
   &__panels {
     width: 100%;
+  }
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  min-height: 44px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  color: var(--text-secondary);
+  position: relative;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      color var(--transition-fast),
+      border-color var(--transition-fast);
+  }
+
+  &:hover:not(&--active) {
+    color: var(--text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  &--active {
+    color: var(--text-primary);
+    border-bottom-color: var(--accent-blue);
+  }
+
+  &__icon {
+    font-size: var(--font-size-lg);
+    line-height: 1;
+  }
+
+  &__label {
+    line-height: 1;
+  }
+
+  @media (forced-colors: active) {
+    &--active {
+      border-bottom-color: Highlight;
+      color: Highlight;
+    }
   }
 }
 </style>

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -41,6 +41,14 @@ const showModal = ref<boolean>(false)
 
 const features: Feature[] = [
   {
+    id: 'component-usage-audit',
+    type: 'feature',
+    title: 'Component Usage Audit',
+    description:
+      "The new <strong>Components</strong> tab lets you audit which of your known Butter CMS components are actually used across individual pages. Unlike Butter CMS's built-in view (which shows which <em>page types</em> reference a component), this tool reveals which specific pages use each component - so you can spot components with zero real-world page usages. Add your component slugs in API Configuration, run an audit, and see results sorted from least-used to most-used. Components with no page usages are flagged with a warning.",
+    utcDatetimeAdded: new Date('2026-02-21T16:45:00Z'),
+  },
+  {
     id: 'status-badges',
     type: 'improvement',
     title: 'Status badges for content items in Search Content results',

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -46,7 +46,7 @@ const features: Feature[] = [
     title: 'Component Usage Audit',
     description:
       "The new <strong>Components</strong> tab lets you audit which of your known Butter CMS components are actually used across individual pages. Unlike Butter CMS's built-in view (which shows which <em>page types</em> reference a component), this tool reveals which specific pages use each component - so you can spot components with zero real-world page usages. Add your component slugs in API Configuration, run an audit, and see results sorted from least-used to most-used. Components with no page usages are flagged with a warning.",
-    utcDatetimeAdded: new Date('2026-02-21T16:45:00Z'),
+    utcDatetimeAdded: new Date('2026-02-21T16:30:00Z'),
   },
   {
     id: 'status-badges',

--- a/src/features/components.spec.ts
+++ b/src/features/components.spec.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { auditComponents } from './components'
+
+const { getAllPages: mockGetAllPages } = vi.hoisted(() => ({
+  getAllPages: vi.fn(),
+}))
+
+vi.mock('@/core/pages', () => ({
+  getAllPages: mockGetAllPages,
+}))
+
+// Helper to build a minimal mock Butter.Page
+function makePage(
+  slug: string,
+  fields: Record<string, unknown>,
+  overrides: Partial<{
+    name: string
+    status: 'published' | 'draft' | 'scheduled'
+    pageType: string
+  }> = {},
+) {
+  return {
+    slug,
+    name: overrides.name ?? slug,
+    page_type: overrides.pageType ?? 'test_page',
+    status: overrides.status ?? 'published',
+    published: overrides.status === 'published' ? '2024-01-01' : null,
+    scheduled: null,
+    updated: null,
+    fields,
+  }
+}
+
+describe('auditComponents', () => {
+  beforeEach(() => {
+    mockGetAllPages.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Input validation', () => {
+    it('returns error when token is empty', async () => {
+      const result = await auditComponents('', false, ['landing_page'], ['hero_banner'])
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('token')
+      expect(result.totalScanned).toBe(0)
+    })
+
+    it('returns error when knownComponents is empty', async () => {
+      const result = await auditComponents('token', false, ['landing_page'], [])
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('components')
+      expect(result.totalScanned).toBe(0)
+    })
+
+    it('returns error when selectedPageTypes is empty', async () => {
+      const result = await auditComponents('token', false, [], ['hero_banner'])
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('page types')
+      expect(result.totalScanned).toBe(0)
+    })
+
+    it('calls getAllPages and returns success with no results when no pages exist', async () => {
+      mockGetAllPages.mockResolvedValueOnce([])
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+      expect(result.success).toBe(true)
+      expect(result.totalScanned).toBe(0)
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]!.componentSlug).toBe('hero_banner')
+      expect(result.results[0]!.usageCount).toBe(0)
+    })
+  })
+
+  describe('Component detection - Strategy 1: object keys', () => {
+    it('detects component used as an object key in fields', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', { hero_banner: { title: 'Hello World' } }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.success).toBe(true)
+      expect(result.results[0]!.componentSlug).toBe('hero_banner')
+      expect(result.results[0]!.usageCount).toBe(1)
+      expect(result.results[0]!.usages[0]!.slug).toBe('page-1')
+    })
+
+    it('detects multiple known components as object keys', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          hero_banner: { title: 'Hello' },
+          cta_block: { text: 'Click me' },
+        }),
+      ])
+
+      const result = await auditComponents(
+        'token',
+        false,
+        ['landing_page'],
+        ['hero_banner', 'cta_block'],
+      )
+
+      expect(result.success).toBe(true)
+      const heroBanner = result.results.find((r) => r.componentSlug === 'hero_banner')
+      const ctaBlock = result.results.find((r) => r.componentSlug === 'cta_block')
+      expect(heroBanner!.usageCount).toBe(1)
+      expect(ctaBlock!.usageCount).toBe(1)
+    })
+
+    it('detects nested object key', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          content: {
+            sections: {
+              hero_banner: { title: 'Nested' },
+            },
+          },
+        }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.results[0]!.usageCount).toBe(1)
+    })
+  })
+
+  describe('Component detection - Strategy 2: type field value', () => {
+    it('detects component via "type" field value', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          components: [
+            { type: 'hero_banner', title: 'Hello' },
+            { type: 'cta_block', text: 'Click me' },
+          ],
+        }),
+      ])
+
+      const result = await auditComponents(
+        'token',
+        false,
+        ['landing_page'],
+        ['hero_banner', 'cta_block'],
+      )
+
+      const heroBanner = result.results.find((r) => r.componentSlug === 'hero_banner')
+      const ctaBlock = result.results.find((r) => r.componentSlug === 'cta_block')
+      expect(heroBanner!.usageCount).toBe(1)
+      expect(ctaBlock!.usageCount).toBe(1)
+    })
+
+    it('detects deeply nested type field', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          layout: {
+            rows: [
+              {
+                cols: [{ type: 'testimonial', quote: 'Great!' }],
+              },
+            ],
+          },
+        }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['testimonial'])
+
+      expect(result.results[0]!.usageCount).toBe(1)
+    })
+
+    it('does not match "type" field when value is not a known component', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          meta: { type: 'unknown_type' },
+        }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.results[0]!.usageCount).toBe(0)
+    })
+  })
+
+  describe('Multiple pages', () => {
+    it('counts usages across multiple pages', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', { hero_banner: { title: 'Page 1' } }),
+        makePage('page-2', { hero_banner: { title: 'Page 2' } }),
+        makePage('page-3', { other_field: 'no component' }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.totalScanned).toBe(3)
+      expect(result.results[0]!.usageCount).toBe(2)
+      expect(result.results[0]!.usages).toHaveLength(2)
+    })
+
+    it('includes correct page data in usages', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('my-page', { hero_banner: {} }, { name: 'My Page', status: 'draft' }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      const usage = result.results[0]!.usages[0]!
+      expect(usage.slug).toBe('my-page')
+      expect(usage.title).toBe('My Page')
+      expect(usage.status).toBe('draft')
+      expect(usage.pageType).toBe('landing_page')
+    })
+  })
+
+  describe('Multiple page types', () => {
+    it('scans all selected page types', async () => {
+      mockGetAllPages
+        .mockResolvedValueOnce([makePage('p1', { hero_banner: {} })])
+        .mockResolvedValueOnce([makePage('p2', { hero_banner: {} })])
+
+      const result = await auditComponents(
+        'token',
+        false,
+        ['landing_page', 'about_page'],
+        ['hero_banner'],
+      )
+
+      expect(result.totalScanned).toBe(2)
+      expect(result.results[0]!.usageCount).toBe(2)
+    })
+
+    it('passes preview flag to getAllPages', async () => {
+      mockGetAllPages.mockResolvedValueOnce([])
+
+      await auditComponents('token', true, ['landing_page'], ['hero_banner'])
+
+      expect(mockGetAllPages).toHaveBeenCalledWith({
+        token: 'token',
+        preview: true,
+        pageType: 'landing_page',
+      })
+    })
+  })
+
+  describe('Failure handling', () => {
+    it('records failed scopes when getAllPages throws', async () => {
+      mockGetAllPages.mockRejectedValueOnce(new Error('Network error'))
+
+      const result = await auditComponents('token', false, ['failing_page'], ['hero_banner'])
+
+      expect(result.success).toBe(true)
+      expect(result.failedScopes).toContain('failing_page')
+      expect(result.totalScanned).toBe(0)
+    })
+
+    it('continues scanning other page types after a failure', async () => {
+      mockGetAllPages
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce([makePage('p1', { hero_banner: {} })])
+
+      const result = await auditComponents(
+        'token',
+        false,
+        ['failing_page', 'good_page'],
+        ['hero_banner'],
+      )
+
+      expect(result.failedScopes).toContain('failing_page')
+      expect(result.totalScanned).toBe(1)
+      expect(result.results[0]!.usageCount).toBe(1)
+    })
+
+    it('returns no failedScopes key when all scopes succeed', async () => {
+      mockGetAllPages.mockResolvedValueOnce([])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.failedScopes).toBeUndefined()
+    })
+  })
+
+  describe('Sorting', () => {
+    it('sorts results ascending by usageCount, with 0-usage components first', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('p1', { components: [{ type: 'cta_block' }, { type: 'cta_block' }] }),
+        makePage('p2', { components: [{ type: 'cta_block' }] }),
+        makePage('p3', { components: [{ type: 'hero_banner' }] }),
+      ])
+
+      const result = await auditComponents(
+        'token',
+        false,
+        ['landing_page'],
+        ['hero_banner', 'cta_block', 'orphan'],
+      )
+
+      // orphan 0 pages, hero_banner 1 page, cta_block 2 pages
+      expect(result.results[0]!.componentSlug).toBe('orphan')
+      expect(result.results[0]!.usageCount).toBe(0)
+      expect(result.results[1]!.componentSlug).toBe('hero_banner')
+      expect(result.results[1]!.usageCount).toBe(1)
+      expect(result.results[2]!.componentSlug).toBe('cta_block')
+      expect(result.results[2]!.usageCount).toBe(2)
+    })
+  })
+
+  describe('Safety mechanisms', () => {
+    it('handles null and undefined values in fields without throwing', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          nullField: null,
+          nested: { another: null, value: undefined },
+        }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.success).toBe(true)
+      expect(result.totalScanned).toBe(1)
+    })
+
+    it('handles circular references via WeakSet without throwing', async () => {
+      const circular: Record<string, unknown> = { name: 'root' }
+      circular['self'] = circular
+
+      mockGetAllPages.mockResolvedValueOnce([makePage('page-1', circular)])
+
+      await expect(
+        auditComponents('token', false, ['landing_page'], ['hero_banner']),
+      ).resolves.not.toThrow()
+    })
+
+    it('handles arrays containing non-objects without throwing', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          tags: ['one', 'two', 3, null, true],
+        }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.success).toBe(true)
+    })
+
+    it('handles pages with empty fields object', async () => {
+      mockGetAllPages.mockResolvedValueOnce([makePage('empty-page', {})])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      expect(result.success).toBe(true)
+      expect(result.results[0]!.usageCount).toBe(0)
+    })
+  })
+
+  describe('Both strategies together', () => {
+    it('finds component via both key and type field on same page (counted once per page)', async () => {
+      mockGetAllPages.mockResolvedValueOnce([
+        makePage('page-1', {
+          hero_banner: { title: 'Permanent' },
+          picker: [{ type: 'hero_banner', title: 'Picker' }],
+        }),
+      ])
+
+      const result = await auditComponents('token', false, ['landing_page'], ['hero_banner'])
+
+      // On one page, even if found multiple ways, we only add one usage entry per page
+      // (the walker finds the component for this page, then we create one ComponentUsage)
+      // Actually looking at our implementation - we count per page based on the Map<componentSlug, count>
+      // If the same component appears both as a key AND as a type value, counts.get('hero_banner') = 2
+      // but we still only push one usage entry for that page.
+      expect(result.results[0]!.usages).toHaveLength(1)
+      expect(result.results[0]!.usageCount).toBe(1)
+    })
+  })
+})

--- a/src/features/components.ts
+++ b/src/features/components.ts
@@ -1,0 +1,174 @@
+import type { Butter } from '@/types'
+import { getAllPages } from '@/core/pages'
+
+export interface ComponentUsage {
+  title: string
+  slug: string
+  pageType: string
+  status: 'published' | 'draft' | 'scheduled' | undefined
+}
+
+export interface ComponentResult {
+  componentSlug: string
+  usageCount: number
+  usages: ComponentUsage[]
+}
+
+export interface ComponentsResponse {
+  success: boolean
+  results: ComponentResult[]
+  totalScanned: number
+  failedScopes?: string[]
+  error?: string
+}
+
+const MAX_DEPTH = 20
+
+/**
+ * Recursively walk a JSON tree to count how many times each known component slug appears.
+ * Component slugs are matched in two ways:
+ *  1. As object keys in `fields` (permanent components permanently added to a page type)
+ *  2. As the value of a `type` field inside an object (Butter CMS Component Picker)
+ */
+function walkJson(
+  node: unknown,
+  slugSet: Set<string>,
+  counts: Map<string, number>,
+  visited: WeakSet<object>,
+  depth: number,
+): void {
+  if (depth > MAX_DEPTH) return
+  if (node === null || node === undefined) return
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      walkJson(item, slugSet, counts, visited, depth + 1)
+    }
+    return
+  }
+
+  if (typeof node === 'object') {
+    if (visited.has(node as object)) return
+    visited.add(node as object)
+
+    const obj = node as Record<string, unknown>
+
+    // Strategy 1: check if any key matches a component slug
+    for (const key of Object.keys(obj)) {
+      if (slugSet.has(key)) {
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+      }
+    }
+
+    // Strategy 2: check if this object has a `type` field matching a component slug
+    if (typeof obj['type'] === 'string' && slugSet.has(obj['type'])) {
+      counts.set(obj['type'], (counts.get(obj['type']) ?? 0) + 1)
+    }
+
+    // Recurse into all values
+    for (const value of Object.values(obj)) {
+      walkJson(value, slugSet, counts, visited, depth + 1)
+    }
+  }
+}
+
+/**
+ * Audit component usage across selected page types.
+ * Returns, for each known component, how many times it appears and on which pages.
+ */
+export async function auditComponents(
+  token: string,
+  preview: boolean,
+  selectedPageTypes: string[],
+  knownComponents: string[],
+): Promise<ComponentsResponse> {
+  if (!token) {
+    return { success: false, results: [], totalScanned: 0, error: 'No API token provided' }
+  }
+
+  if (knownComponents.length === 0) {
+    return {
+      success: false,
+      results: [],
+      totalScanned: 0,
+      error: 'No known components configured',
+    }
+  }
+
+  if (selectedPageTypes.length === 0) {
+    return {
+      success: false,
+      results: [],
+      totalScanned: 0,
+      error: 'No page types selected',
+    }
+  }
+
+  const slugSet = new Set(knownComponents)
+  // Map: componentSlug -> list of pages where it appears
+  const usageMap = new Map<string, ComponentUsage[]>()
+  for (const slug of knownComponents) {
+    usageMap.set(slug, [])
+  }
+
+  const failedScopes: string[] = []
+  let totalScanned = 0
+
+  for (const pageType of selectedPageTypes) {
+    let pages: Butter.Page[]
+    try {
+      pages = await getAllPages({ token, preview, pageType })
+    } catch {
+      failedScopes.push(pageType)
+      continue
+    }
+
+    for (const page of pages) {
+      totalScanned++
+
+      const counts = new Map<string, number>()
+      const visited = new WeakSet<object>()
+      walkJson(page.fields, slugSet, counts, visited, 0)
+
+      if (counts.size > 0) {
+        const usage: ComponentUsage = {
+          title: (page as Butter.Page).name ?? page.slug,
+          slug: page.slug,
+          pageType,
+          status: page.status,
+        }
+
+        for (const [componentSlug, count] of counts.entries()) {
+          if (count > 0) {
+            const existingUsages = usageMap.get(componentSlug) ?? []
+            // Store one entry per page (the count per page is folded into a single entry)
+            existingUsages.push(usage)
+            usageMap.set(componentSlug, existingUsages)
+          }
+        }
+      }
+
+      // Yield to the main thread between pages to avoid blocking during large crawls
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    }
+  }
+
+  const results: ComponentResult[] = knownComponents.map((componentSlug) => {
+    const usages = usageMap.get(componentSlug) ?? []
+    return {
+      componentSlug,
+      usageCount: usages.length,
+      usages,
+    }
+  })
+
+  // Sort: 0-usage components first, then ascending by usage count
+  results.sort((a, b) => a.usageCount - b.usageCount)
+
+  return {
+    success: true,
+    results,
+    totalScanned,
+    failedScopes: failedScopes.length > 0 ? failedScopes : undefined,
+  }
+}

--- a/src/stores/index.spec.ts
+++ b/src/stores/index.spec.ts
@@ -29,6 +29,7 @@ describe('useStore', () => {
       expect(store.includePreview).toBe(false)
       expect(store.pageTypes).toEqual([])
       expect(store.collectionKeys).toEqual([])
+      expect(store.knownComponents).toEqual([])
       expect(store.selectedScopes).toEqual({
         blog: false,
         pageTypes: [],
@@ -360,6 +361,7 @@ describe('useStore', () => {
         includePreview: true,
         pageTypes: ['landing_page'],
         collectionKeys: ['products'],
+        knownComponents: [],
         activeTabIndex: 0,
         selectedScopes: {
           blog: true,
@@ -435,6 +437,103 @@ describe('useStore', () => {
 
       // Should return empty array for null
       expect(store.pageTypes).toEqual([])
+    })
+  })
+
+  describe('Known Components Management', () => {
+    it('should initialize with empty knownComponents by default', () => {
+      const store = useStore()
+      expect(store.knownComponents).toEqual([])
+    })
+
+    it('should load knownComponents from localStorage when available', () => {
+      localStorage.setItem(
+        'butter_cms_config',
+        JSON.stringify({
+          token: 'test-token',
+          lockToken: false,
+          includePreview: false,
+          pageTypes: [],
+          collectionKeys: [],
+          knownComponents: ['hero_banner', 'cta_block'],
+          activeTabIndex: 0,
+          selectedScopes: { blog: false, pageTypes: [], collectionKeys: [] },
+        }),
+      )
+
+      setActivePinia(createPinia())
+      const store = useStore()
+
+      expect(store.knownComponents).toEqual(['hero_banner', 'cta_block'])
+    })
+
+    it('should default to empty array when knownComponents is missing from localStorage', () => {
+      localStorage.setItem(
+        'butter_cms_config',
+        JSON.stringify({
+          token: 'test-token',
+          lockToken: false,
+          includePreview: false,
+          pageTypes: [],
+          collectionKeys: [],
+          activeTabIndex: 0,
+          selectedScopes: { blog: false, pageTypes: [], collectionKeys: [] },
+        }),
+      )
+
+      setActivePinia(createPinia())
+      const store = useStore()
+
+      expect(store.knownComponents).toEqual([])
+    })
+
+    it('should add known components', () => {
+      const store = useStore()
+
+      store.knownComponents = ['hero_banner', 'testimonial']
+
+      expect(store.knownComponents).toEqual(['hero_banner', 'testimonial'])
+    })
+
+    it('should remove known components', () => {
+      const store = useStore()
+
+      store.knownComponents = ['hero_banner', 'cta_block', 'testimonial']
+      store.knownComponents = store.knownComponents.filter((c) => c !== 'cta_block')
+
+      expect(store.knownComponents).toEqual(['hero_banner', 'testimonial'])
+    })
+
+    it('should clear known components', () => {
+      const store = useStore()
+
+      store.knownComponents = ['hero_banner']
+      store.knownComponents = []
+
+      expect(store.knownComponents).toEqual([])
+    })
+
+    it('should persist knownComponents to localStorage', async () => {
+      const store = useStore()
+
+      store.knownComponents = ['hero_banner', 'cta_block']
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      const stored = JSON.parse(localStorage.getItem('butter_cms_config')!)
+      expect(stored.knownComponents).toEqual(['hero_banner', 'cta_block'])
+    })
+
+    it('should persist knownComponents across store instances', async () => {
+      const store1 = useStore()
+      store1.knownComponents = ['my_component']
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      setActivePinia(createPinia())
+      const store2 = useStore()
+
+      expect(store2.knownComponents).toEqual(['my_component'])
     })
   })
 })

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -9,6 +9,7 @@ export const useStore = defineStore('store', () => {
     includePreview: boolean
     pageTypes: string[]
     collectionKeys: string[]
+    knownComponents: string[]
     activeTabIndex: number
     selectedScopes: {
       blog: boolean
@@ -27,10 +28,14 @@ export const useStore = defineStore('store', () => {
             parsed.activeTabIndex >= 0 &&
             parsed.activeTabIndex < 10
           ) {
-            return { ...parsed, activeTabIndex: parsed.activeTabIndex }
+            return {
+              ...parsed,
+              activeTabIndex: parsed.activeTabIndex,
+              knownComponents: parsed.knownComponents ?? [],
+            }
           }
           // If invalid or missing, default to 0
-          return { ...parsed, activeTabIndex: 0 }
+          return { ...parsed, activeTabIndex: 0, knownComponents: parsed.knownComponents ?? [] }
         } catch {
           console.warn('Failed to parse stored config, using defaults')
         }
@@ -41,6 +46,7 @@ export const useStore = defineStore('store', () => {
         includePreview: false,
         pageTypes: [],
         collectionKeys: [],
+        knownComponents: [],
         activeTabIndex: 0,
         selectedScopes: {
           blog: false,
@@ -84,6 +90,13 @@ export const useStore = defineStore('store', () => {
     get: () => config.value.collectionKeys ?? [],
     set: (val: string[]) => {
       config.value.collectionKeys = val
+    },
+  })
+
+  const knownComponents = computed({
+    get: () => config.value.knownComponents ?? [],
+    set: (val: string[]) => {
+      config.value.knownComponents = val
     },
   })
 
@@ -145,6 +158,7 @@ export const useStore = defineStore('store', () => {
     includePreview,
     pageTypes,
     collectionKeys,
+    knownComponents,
     selectedScopes,
     activeTabIndex,
   }


### PR DESCRIPTION
Audit which of your known Butter CMS components are actually used across individual pages — complementing Butter CMS's built-in view, which shows which page types reference a component.

Resolves #14 